### PR TITLE
CTCP-3999: Add scenarios for notSure in pre-lodged

### DIFF
--- a/app/models/journeyDomain/equipment/EquipmentsAndChargesDomain.scala
+++ b/app/models/journeyDomain/equipment/EquipmentsAndChargesDomain.scala
@@ -42,8 +42,19 @@ object EquipmentsAndChargesDomain {
     ContainerIndicatorPage.reader.map(_.value).flatMap {
       case Some(true) =>
         UserAnswersReader[EquipmentsDomain].map(Option(_))
-      case _ =>
+      case Some(false) =>
         AddTransportEquipmentYesNoPage.filterOptionalDependent(identity) {
+          UserAnswersReader[EquipmentsDomain]
+        }
+      case _ =>
+        handleContainerNotSure
+    }
+
+  private def handleContainerNotSure =
+    SecurityDetailsTypePage.reader.flatMap {
+      case NoSecurityDetails => UserAnswersReader[EquipmentsDomain].map(Option(_))
+      case _ =>
+        AddPaymentMethodYesNoPage.filterOptionalDependent(identity) {
           UserAnswersReader[EquipmentsDomain]
         }
     }

--- a/app/models/journeyDomain/equipment/EquipmentsAndChargesDomain.scala
+++ b/app/models/journeyDomain/equipment/EquipmentsAndChargesDomain.scala
@@ -19,8 +19,8 @@ package models.journeyDomain.equipment
 import cats.implicits._
 import config.Constants._
 import models.domain.{GettableAsFilterForNextReaderOps, GettableAsReaderOps, UserAnswersReader}
-import models.reference.equipment.PaymentMethod
 import models.journeyDomain.JourneyDomainModel
+import models.reference.equipment.PaymentMethod
 import pages.equipment._
 import pages.external.SecurityDetailsTypePage
 import pages.preRequisites.ContainerIndicatorPage
@@ -32,13 +32,12 @@ case class EquipmentsAndChargesDomain(
 
 object EquipmentsAndChargesDomain {
 
-  implicit val userAnswersReader: UserAnswersReader[EquipmentsAndChargesDomain] =
-    for {
-      equipments    <- equipmentsReads
-      paymentMethod <- if (equipments.isDefined) chargesReads else none[PaymentMethod].pure[UserAnswersReader]
-    } yield EquipmentsAndChargesDomain(equipments, paymentMethod)
+  implicit val userAnswersReader: UserAnswersReader[EquipmentsAndChargesDomain] = (
+    equipmentsReader,
+    chargesReader
+  ).tupled.map((EquipmentsAndChargesDomain.apply _).tupled)
 
-  implicit lazy val equipmentsReads: UserAnswersReader[Option[EquipmentsDomain]] =
+  implicit lazy val equipmentsReader: UserAnswersReader[Option[EquipmentsDomain]] =
     ContainerIndicatorPage.reader.map(_.value).flatMap {
       case Some(true) =>
         UserAnswersReader[EquipmentsDomain].map(Option(_))
@@ -46,20 +45,11 @@ object EquipmentsAndChargesDomain {
         AddTransportEquipmentYesNoPage.filterOptionalDependent(identity) {
           UserAnswersReader[EquipmentsDomain]
         }
-      case _ =>
-        handleContainerNotSure
+      case None =>
+        none[EquipmentsDomain].pure[UserAnswersReader]
     }
 
-  private def handleContainerNotSure =
-    SecurityDetailsTypePage.reader.flatMap {
-      case NoSecurityDetails => none[EquipmentsDomain].pure[UserAnswersReader]
-      case _ =>
-        AddPaymentMethodYesNoPage.filterOptionalDependent(identity) {
-          UserAnswersReader[EquipmentsDomain]
-        }
-    }
-
-  implicit lazy val chargesReads: UserAnswersReader[Option[PaymentMethod]] = SecurityDetailsTypePage.reader.flatMap {
+  implicit lazy val chargesReader: UserAnswersReader[Option[PaymentMethod]] = SecurityDetailsTypePage.reader.flatMap {
     case NoSecurityDetails => none[PaymentMethod].pure[UserAnswersReader]
     case _                 => AddPaymentMethodYesNoPage.filterOptionalDependent(identity)(PaymentMethodPage.reader)
   }

--- a/app/models/journeyDomain/equipment/EquipmentsAndChargesDomain.scala
+++ b/app/models/journeyDomain/equipment/EquipmentsAndChargesDomain.scala
@@ -52,7 +52,7 @@ object EquipmentsAndChargesDomain {
 
   private def handleContainerNotSure =
     SecurityDetailsTypePage.reader.flatMap {
-      case NoSecurityDetails => UserAnswersReader[EquipmentsDomain].map(Option(_))
+      case NoSecurityDetails => none[EquipmentsDomain].pure[UserAnswersReader]
       case _ =>
         AddPaymentMethodYesNoPage.filterOptionalDependent(identity) {
           UserAnswersReader[EquipmentsDomain]

--- a/test/models/journeyDomain/equipment/EquipmentsAndChargesDomainSpec.scala
+++ b/test/models/journeyDomain/equipment/EquipmentsAndChargesDomainSpec.scala
@@ -61,7 +61,7 @@ class EquipmentsAndChargesDomainSpec extends SpecBase with ScalaCheckPropertyChe
               val result: EitherType[Option[EquipmentsDomain]] = UserAnswersReader[Option[EquipmentsDomain]](
                 EquipmentsAndChargesDomain.equipmentsReads
               ).run(userAnswers)
-              result.value must be(defined)
+              result.value must not be defined
           }
         }
       }

--- a/test/models/journeyDomain/equipment/EquipmentsAndChargesDomainSpec.scala
+++ b/test/models/journeyDomain/equipment/EquipmentsAndChargesDomainSpec.scala
@@ -17,7 +17,7 @@
 package models.journeyDomain.equipment
 
 import base.SpecBase
-import config.Constants.NoSecurityDetails
+import config.Constants.{NoSecurityDetails, TIR}
 import generators.{Generators, UserAnswersGenerator}
 import models.domain.{EitherType, UserAnswersReader}
 import models.reference.equipment.PaymentMethod
@@ -49,6 +49,39 @@ class EquipmentsAndChargesDomainSpec extends SpecBase with ScalaCheckPropertyChe
           result.value mustBe expectedResult
         }
       }
+
+      "when container indicator is maybe (not sure) and NoSecurityDetails" - {
+        "redirect to next page" in {
+          val initialAnswers = emptyUserAnswers
+            .setValue(ContainerIndicatorPage, OptionalBoolean.maybe)
+            .setValue(SecurityDetailsTypePage, NoSecurityDetails)
+
+          forAll(arbitraryEquipmentAnswers(initialAnswers, Index(0))) {
+            userAnswers =>
+              val result: EitherType[Option[EquipmentsDomain]] = UserAnswersReader[Option[EquipmentsDomain]](
+                EquipmentsAndChargesDomain.equipmentsReads
+              ).run(userAnswers)
+              result.value must be(defined)
+          }
+        }
+      }
+
+      "when container indicator is maybe (not sure) with Security" - {
+        "redirect to AddPaymentMethodYesNoPage" in {
+          val initialAnswers = emptyUserAnswers
+            .setValue(ContainerIndicatorPage, OptionalBoolean.maybe)
+            .setValue(SecurityDetailsTypePage, TIR)
+
+          forAll(arbitraryEquipmentAnswers(initialAnswers, Index(0))) {
+            userAnswers =>
+              val result: EitherType[Option[EquipmentsDomain]] = UserAnswersReader[Option[EquipmentsDomain]](
+                EquipmentsAndChargesDomain.equipmentsReads
+              ).run(userAnswers)
+              result.left.value.page mustBe AddPaymentMethodYesNoPage
+          }
+        }
+      }
+
     }
 
     "equipmentsReads" - {


### PR DESCRIPTION
![Screenshot 2023-10-06 at 10 11 54](https://github.com/hmrc/ctc-departure-transport-details-frontend/assets/12535866/4beda161-de42-4c4d-9771-8037c9f7459c)

For CTCP-3999 most scenarios appear to have already been completed. The last 3 on the ticket weren't working as expected for the path where not sure was selected for the container question in pre-lodged. This change introduces them